### PR TITLE
Added a setting option to show/hide the PopOut! / PopIn! button label (default: shown)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2,6 +2,7 @@
     "POPOUT.PopOut": "PopOut!",
     "POPOUT.PopIn": "PopIn!",
     "POPOUT.showButton": "Show PopOut! Button.",
+    "POPOUT.showButtonLabel": "Show PopOut! Button label.",
     "POPOUT.useWindows": "Pop sheets out into windows",
     "POPOUT.useWindowsHint": "Force the popped out sheet to be a window with minimal decorations. Otherwise uses your browser's default (a new tab most likely)",
     "POPOUT.boundingBox": "Bounding box compatibility mode",

--- a/popout.js
+++ b/popout.js
@@ -61,6 +61,13 @@ class PopoutModule {
       default: true,
       type: Boolean,
     });
+    game.settings.register("popout", "showButtonLabel", {
+      name: game.i18n.localize("POPOUT.showButtonLabel"),
+      scope: "client",
+      config: true,
+      default: true,
+      type: Boolean,
+    });
     game.settings.register("popout", "useWindows", {
       name: game.i18n.localize("POPOUT.useWindows"),
       hint: game.i18n.localize("POPOUT.useWindowsHint"),
@@ -165,10 +172,9 @@ class PopoutModule {
     if (!document.getElementById(domID)) {
       // Don't create a second link on re-renders;
       /* eslint-disable no-undef */
+      let label = game.settings.get("popout", "showButtonLabel") ? game.i18n.localize("POPOUT.PopOut") : "";
       const link = $(
-        `<a id="${domID}"><i class="fas fa-external-link-alt"></i>${game.i18n.localize(
-          "POPOUT.PopOut"
-        )}</a>`
+        `<a id="${domID}"><i class="fas fa-external-link-alt"></i>${label}</a>`
       );
       /* eslint-enable no-undef */
 
@@ -467,11 +473,10 @@ class PopoutModule {
       if (child.id == domID) {
         // Change Close button
         /* eslint-disable no-unused-vars, no-undef */
+        let label = game.settings.get("popout", "showButtonLabel") ? game.i18n.localize("POPOUT.PopIn") : "";
         $(child)
           .html(
-            `<i class="fas fa-sign-in-alt"></i>${game.i18n.localize(
-              "POPOUT.PopIn"
-            )}`
+            `<i class="fas fa-sign-in-alt"></i>${label}`
           )
           .off("click")
           .on("click", (event) => {


### PR DESCRIPTION
Added a setting option to hide the PopOut! / PopIn! button label (keeping only the fas icon visible) for compatibility with modules, such as Monarch, which display a vertical menu bar with no button labels.