### PR TITLE
Prevent wrong base URL

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -808,7 +808,7 @@ Hooks.on("ready", () => {
     if (window.ui.PDFoundry !== undefined) {
       app._viewer = false;
       if (app.pdfData && app.pdfData.url !== undefined) {
-        app.open(app.pdfData.url, app.pdfData.offset);
+        app.open(new URL(app.pdfData.url, window.location).href, app.pdfData.offset);
       }
       if (app.onViewerReady !== undefined) {
         app.onViewerReady();


### PR DESCRIPTION
If the pdf path is only provided as a relative path, pdfjs will add the base from window.location. This can lead to wrong URLs as the base url of the poput frame is used instead of the main vtt application.

This makes it so the base url of the main application is used!