### PR TITLE
Add support for TyphonJS Runtime Library / Svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ For an example of what that might look like, see the PDFoundry compatibility hoo
 Hooks.callAll("PopOut:popout", app, popout);
 
 // app: is the foundry application being popped out.
+// popout: is the browser window object where the popped out element will be moved.
+Hooks.callAll("Popout:loading", app, popout);
+
+// app: is the foundry application being popped out.
 // node: is the html element of the application after it has been moved to the new window.
 Hooks.callAll("Popout:loaded", app, node);
 

--- a/popout.js
+++ b/popout.js
@@ -226,13 +226,13 @@ class PopoutModule {
         buttonText = "";
       }
       const link = $(
-        `<a id="${domID}" class="popout-module-button"><i class="fas fa-external-link-alt" title="${game.i18n.localize(
+        `<a id="${domID}" class="popout-module-button header-button"><i class="fas fa-external-link-alt" title="${game.i18n.localize(
           "POPOUT.PopOut"
         )}"></i>${buttonText}</a>`
       );
       /* eslint-enable no-undef */
 
-      link.on("pointerdown", () => this.onPopoutClicked(app));
+      link.on("click", () => this.onPopoutClicked(app));
       // eslint-disable-next-line no-undef
       if (game && game.settings.get("popout", "showButton")) {
         app.element.find(".window-title").after(link);

--- a/popout.js
+++ b/popout.js
@@ -232,7 +232,7 @@ class PopoutModule {
       );
       /* eslint-enable no-undef */
 
-      link.on("click", () => this.onPopoutClicked(app));
+      link.on("pointerdown", () => this.onPopoutClicked(app));
       // eslint-disable-next-line no-undef
       if (game && game.settings.get("popout", "showButton")) {
         app.element.find(".window-title").after(link);
@@ -577,6 +577,8 @@ class PopoutModule {
 
     // -------------------- Add unload handlers --------------------
 
+    Hooks.callAll("PopOut:loading", app, popout);
+
     window.addEventListener("unload", async (event) => {
       this.log("Unload event", event);
       const appId = app.appId;
@@ -821,7 +823,6 @@ class PopoutModule {
         if (game.keyboard.downKeys.has("Escape")) return; // eslint-disable-line no-undef
       }
       popout.close();
-      return oldClose.apply(app, args);
     };
 
     const oldMinimize = app.minimize.bind(app);


### PR DESCRIPTION
This PR adds support for the [TyphonJS Runtime Library](https://github.com/typhonjs-fvtt-lib/typhonjs) / Svelte. 

There are only 3 lines modified. 

- First change is the popout app header button event listener from "click" to "pointerdown"
- The second adds a new hook `PopOut:loading` right after the browser window has been created with new document.
- The third removes an unnecessary invocation of the original app close method in the overridden popped out app. 

None of these changes affect the functioning of the app for core / stock Foundry packages.

Also added comments about the new hook in the README. 