### PR TITLE
Override max-height for sidebar popouts

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -755,6 +755,7 @@ class PopoutModule {
                 margin: 0 !important;
                 border-radius: 0 !important;
                 cursor: auto !important;
+                max-height: 100vh;
             `; // Fullscreen
       app.setPosition({ width: "100%", height: "100%", top: 0, left: 0 });
       app._minimized = null;


### PR DESCRIPTION
Foundry defines floating sidebar windows to have a max-height of 90vh, this causes a 10% height margin at the bottom popped out sidebar windows: chat, combat tracker, etc. Setting the popped out node's max-height to 100vh overrides this behavior for popped out windows and allows sidebars to extend to the bottom of windows.

Before and after:
![image](https://github.com/user-attachments/assets/ffbb7055-678e-43e2-a293-1fe6a594156a)
