### PR TITLE
Make app function replacements `async`

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1242,13 +1242,13 @@ class PopoutModule {
     };
 
     const oldRender = app.render.bind(app);
-    app.render = (...args) => {
+    app.render = async (...args) => {
       this.log("Intercepted popout render", app);
       return oldRender.apply(app, args);
     };
 
     const oldClose = app.close.bind(app);
-    app.close = (...args) => {
+    app.close = async (...args) => {
       this.log("Intercepted popout close.", app);
       // Prevent closing of popped out windows with ESC in main page
 
@@ -1263,7 +1263,7 @@ class PopoutModule {
     };
 
     const oldMinimize = app.minimize.bind(app);
-    app.minimize = (...args) => {
+    app.minimize = async (...args) => {
       this.log(
         "Intercepted minimize on popped out app - ignoring:",
         app.constructor.name,
@@ -1274,7 +1274,7 @@ class PopoutModule {
     };
 
     const oldMaximize = app.maximize.bind(app);
-    app.maximize = (...args) => {
+    app.maximize = async (...args) => {
       this.log(
         "Intercepted maximize on popped out app - focusing popout instead:",
         app.constructor.name,


### PR DESCRIPTION
Both AppV1 / AppV2 methods for `close`, `maximize`, `minimize`, and `render` are `async`. The temporary replacement functions set when popped out are not async and cause chaining issues internal to Foundry when a Promise is expected to be returned. For instance if `render` is called on a popped out window Foundry internally to render will chain on `maximize` with `this.maximize().then(() => this.bringToTop());`. Since the popout replacement functions are not `async` this will fail at the `.then` continuation internal to Foundry and cause an error. 

This PR just makes the appropriate popout replacement functions `async`.