### PR TITLE
Fix hotbar digit keys intercepting input in popped-out application windows

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -34,6 +34,49 @@ class PopoutModule {
     this.ID = (foundry?.utils?.randomID || randomID)(24);
   }
 
+  /**
+   * Whether `element` counts as keyboard "typing" context (Foundry hasFocus semantics).
+   * Uses the element's own Window/HTMLElement so popout documents work (cross-realm instanceof).
+   */
+  static isKeyboardTypingContext(element) {
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) return false;
+    const win = element.ownerDocument?.defaultView;
+    if (!win?.HTMLElement || !(element instanceof win.HTMLElement)) return false;
+
+    const isV13 =
+      game.release?.generation >= 13 ||
+      (foundry.utils?.isNewerVersion &&
+        foundry.utils.isNewerVersion(game.version, "13.0.0"));
+
+    if (isV13) {
+      if (["", "true"].includes(element.dataset.keyboardFocus)) return true;
+      if (element.dataset.keyboardFocus === "false") return false;
+      if (["INPUT", "SELECT", "TEXTAREA"].includes(element.tagName))
+        return true;
+      if (element.isContentEditable) return true;
+      if (element.tagName === "BUTTON" && element.form) return true;
+      return false;
+    }
+    return true;
+  }
+
+  /** True if the event path includes a typing context (shadow DOM / nested editors). */
+  static keyboardEventTargetsTypingContext(event) {
+    const path =
+      typeof event.composedPath === "function" ? event.composedPath() : [];
+    const nodes = path.length ? path : event.target ? [event.target] : [];
+    for (const n of nodes) {
+      const el =
+        n?.nodeType === Node.ELEMENT_NODE
+          ? n
+          : n?.nodeType === Node.TEXT_NODE
+            ? n.parentElement
+            : null;
+      if (el && PopoutModule.isKeyboardTypingContext(el)) return true;
+    }
+    return false;
+  }
+
   log(msg, ...args) {
     if (game && game.settings.get("popout", "verboseLogs")) {
       const color = "background: #6699ff; color: #000; font-size: larger;";
@@ -265,34 +308,21 @@ class PopoutModule {
         (foundry.utils?.isNewerVersion &&
           foundry.utils.isNewerVersion(game.version, "13.0.0"));
 
-      // Helper function to check if an element has focus based on version
-      const checkElementFocus = (element) => {
-        if (!(element instanceof HTMLElement)) return false;
-
-        if (isV13) {
-          // v13 logic with dataset and specific checks
-          if (["", "true"].includes(element.dataset.keyboardFocus)) return true;
-          if (element.dataset.keyboardFocus === "false") return false;
-          if (["INPUT", "SELECT", "TEXTAREA"].includes(element.tagName))
-            return true;
-          if (element.isContentEditable) return true;
-          if (element.tagName === "BUTTON" && element.form) return true;
-          return false;
-        } else {
-          // v12 logic - any focused HTMLElement counts
-          return true;
-        }
-      };
-
       // Create the new hasFocus implementation that checks popouts
       const newHasFocus = () => {
         // Check main document
-        if (checkElementFocus(document.activeElement)) return true;
+        if (PopoutModule.isKeyboardTypingContext(document.activeElement))
+          return true;
 
         // Check all popped out windows
         for (const val of this.poppedOut.values()) {
           if (!val.window || val.window.closed) continue;
-          if (checkElementFocus(val.window.document.activeElement)) return true;
+          if (
+            PopoutModule.isKeyboardTypingContext(
+              val.window.document.activeElement,
+            )
+          )
+            return true;
         }
 
         return false;
@@ -1550,7 +1580,9 @@ class PopoutModule {
 
       // Forward keyboard events to main window for keybinding support
       // NOTE: v13 changed the keyboard API, #handleKeyboardEvent is now private
+      // Skip forwarding when typing in inputs/editors (incl. shadow DOM); core may use main-realm instanceof on event.target.
       popout.addEventListener("keydown", (event) => {
+        if (PopoutModule.keyboardEventTargetsTypingContext(event)) return;
         if (window.keyboard && window.keyboard._handleKeyboardEvent) {
           // v12 and earlier - use internal method
           window.keyboard._handleKeyboardEvent(event, false);
@@ -1561,6 +1593,7 @@ class PopoutModule {
         }
       });
       popout.addEventListener("keyup", (event) => {
+        if (PopoutModule.keyboardEventTargetsTypingContext(event)) return;
         if (window.keyboard && window.keyboard._handleKeyboardEvent) {
           // v12 and earlier - use internal method
           window.keyboard._handleKeyboardEvent(event, true);


### PR DESCRIPTION
# Fix hotbar digit keys intercepting input in popped-out application windows

## Summary

When an application (e.g. an actor sheet) is opened in a **PopOut** child window, pressing number keys **0–9** that are bound to **hotbar** slots while focused in a **text or number field** did not type the digit and instead **triggered the macro**, even though focus appeared to be in the popout window.

This PR fixes that by making keyboard “typing context” detection **realm-safe** for DOM nodes that live in the popout `document`, and by **not forwarding** those keyboard events to Foundry’s global keyboard handler when the event path indicates typing in an input/editor (including shadow DOM).

## Motivation

PopOut **forwards** `keydown` / `keyup` from the auxiliary window to Foundry’s keyboard layer (`window.keyboard` on v12, `game.keyboard` on v13+) so global keybindings keep working when the popout is focused. That is intentional and valuable.

If Foundry (or downstream logic) believes **no** element has “typing focus”, it treats digit keys as **keybindings** (e.g. hotbar slots) and may call `preventDefault` on the same `KeyboardEvent`, which **blocks normal character entry** in the focused field.

So the module must correctly report “user is typing in a field” for **both** the main document and **popout** documents.

## Root cause

The existing `hasFocus` override already iterated `document.activeElement` across main + popout windows, but the helper used:

```js
element instanceof HTMLElement
```

where `HTMLElement` comes from the **main window’s** JavaScript realm (the realm in which the module script runs). Nodes belonging to a **different** `Window` (the PopOut window) **fail** `instanceof` against another realm’s `HTMLElement` ([`instanceof` across multiple globals / frames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_context_e.g._frames_or_windows)).

So for an `<input>` in the popout, the check always failed → the patched `hasFocus` stayed **false** → Foundry treated digit keys as hotbar bindings instead of text input.

## Why this solution

1. **Realm-neutral element check**  
   Use the element’s own realm:  
   `element instanceof element.ownerDocument.defaultView.HTMLElement`  
   with guards for `nodeType`, missing `ownerDocument`, and closed windows. This matches Foundry’s notion of a keyboard “typing” target without assuming all nodes share the main window’s constructors.

2. **`PopoutModule.isKeyboardTypingContext(element)`**  
   Centralizes the same rules Foundry documents for v13-style focus (`dataset.keyboardFocus`, `INPUT` / `SELECT` / `TEXTAREA`, `contentEditable`, `BUTTON` inside a `form`) and keeps v12 behavior (“any focused element in its own realm counts”). Used by the `hasFocus` patch.

3. **`PopoutModule.keyboardEventTargetsTypingContext(event)` + early return on forward**  
   Even with a correct `hasFocus`, core or other code paths might still inspect `event.target` with **main-realm** `instanceof`. Skipping the forward to `_handleKeyboardEvent` / `_processKeyboardContext` when `composedPath()` hits a typing context (including shadow roots / nested editors) avoids that class of bugs without removing forwarding for non-typing UI.

We **do not** remove keyboard forwarding globally (that would break legitimate global hotkeys when focus is on non-input chrome). We **do not** patch Foundry core; the fix stays inside the module and aligns with the compatibility range in `module.json`.

## Manual testing

1. Assign macros to hotbar slots on digits **1–9** (and **0** if used).
2. Pop out an actor sheet, focus a numeric or text field.
3. Press digits: characters should **insert**; hotbar macros should **not** fire.
4. Click a neutral area of the sheet (not an input), trigger a global hotkey: forwarding should **still** reach the core keyboard layer.

## Files changed

- `popout.js` — `PopoutModule` static helpers, `overrideHasFocus` / `newHasFocus`, popout `keydown` / `keyup` listeners.
