### PR TITLE
Verify PopOut on Foundry V14 and fix popped-out input focus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version number (e.g., 2.22)"
+        description: "Version number (e.g., 2.24.0)"
         required: true
         type: string
       release_notes:
@@ -39,30 +39,38 @@ jobs:
 
       - name: Validate version format
         run: |
-          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+$'; then
-            echo "Error: Version must be in format X.Y (e.g., 2.22)"
+          if ! echo "${{ inputs.version }}" | grep -qE '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            echo "Error: Version must be in format X.Y, X.Y.Z, vX.Y, or vX.Y.Z (e.g., 2.24.0 or v2.24.0)"
             exit 1
           fi
 
+      - name: Normalize version
+        id: version
+        run: |
+          VERSION="${{ inputs.version }}"
+          VERSION="${VERSION#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Check tag doesn't exist
         run: |
-          if git ls-remote --tags origin | grep -q "refs/tags/v${{ inputs.version }}$"; then
-            echo "Error: Tag v${{ inputs.version }} already exists"
+          if git ls-remote --tags origin | grep -q "refs/tags/${{ steps.version.outputs.tag }}$"; then
+            echo "Error: Tag ${{ steps.version.outputs.tag }} already exists"
             exit 1
           fi
 
       - name: Validate Foundry release (dry-run)
         env:
           FOUNDRY_VTT_API_KEY: ${{ secrets.FOUNDRY_VTT_API_KEY }}
-        run: npm run foundry:release -- --version "${{ inputs.version }}" --dry-run
+        run: npm run foundry:release -- --version "${{ steps.version.outputs.version }}" --dry-run
 
       - name: Update module.json
         run: |
           # Update version
-          sed -i 's/"version": "[^"]*"/"version": "${{ inputs.version }}"/' module.json
+          sed -i 's/"version": "[^"]*"/"version": "${{ steps.version.outputs.version }}"/' module.json
 
           # Update download URL
-          sed -i 's|"download": "[^"]*"|"download": "https://github.com/${{ github.repository }}/archive/v${{ inputs.version }}.zip"|' module.json
+          sed -i 's|"download": "[^"]*"|"download": "https://github.com/${{ github.repository }}/archive/refs/tags/${{ steps.version.outputs.tag }}.zip"|' module.json
 
           # Verify changes
           echo "Updated module.json:"
@@ -73,23 +81,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add module.json
-          git commit -m "Release v${{ inputs.version }}"
+          git commit -m "Release ${{ steps.version.outputs.tag }}"
 
       - name: Create and push tag
         run: |
-          git tag "v${{ inputs.version }}"
+          git tag "${{ steps.version.outputs.tag }}"
           git push origin HEAD:${{ github.ref_name }}
-          git push origin "v${{ inputs.version }}"
+          git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${{ inputs.version }}" \
-            --title "v${{ inputs.version }}" \
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
             --notes "${{ inputs.release_notes }}"
 
       - name: Notify Foundry registry
         env:
           FOUNDRY_VTT_API_KEY: ${{ secrets.FOUNDRY_VTT_API_KEY }}
-        run: npm run foundry:release -- --version "${{ inputs.version }}"
+        run: npm run foundry:release -- --version "${{ steps.version.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -1,122 +1,62 @@
-# [PopOut!](https://foundryvtt.com/packages/popout)
+# PopOut!
 
-This module adds a PopOut! button to most actor sheets, journal entries, and applications.
+PopOut! adds a button to most Foundry VTT actor sheets, item sheets, journal entries, and application windows so they can be opened in a separate browser window. It is useful for multi-monitor setups or for keeping frequently referenced sheets visible while working elsewhere in Foundry.
 
-The PopOut! button allows you to open a sheet/application/document into its own window, for easier viewing or for use with multiple monitors.
+## Install
 
-This module **does not work** in the Electron window (the standalone FVTT Application) and can only be used from regular browsers. (i.e. visiting localhost:30000 if you are running it yourself.)
+Install PopOut! from Foundry's **Add-on Modules** screen with this manifest URL:
 
-This module is currently tested on Chrome and ~Firefox~ and under MacOS, ~Linux~, and Windows 10.
+```text
+https://raw.githubusercontent.com/League-of-Foundry-Developers/fvtt-module-popout/master/module.json
+```
 
-This module is only tested against the base Foundry application using the DnD5e system. While most other systems and modules _should_ work; Just because there is a PopOut! button on a window, does not guarantee that it _will_ work.
-
-Systems such as Pathfinder that heavily make use of JQuery or JQuery plugins will have severely limited functionality.
-
-In addition, systems using more advanced frameworks like react/svelte/vue will likely _not_ work and can not be made to work.
-
-Due to the necessarily brittle nature of how this module is implemented, other modules may lack functionality or break completely when popped out. See the Compatibility section for a description of how you can fix this if you are module developer.
-
-### Firefox
-
-~Due to a recent update from Firefox that changed the way the `instanceof` method works~ Turns out [the issue](https://bugzilla.mozilla.org/show_bug.cgi?id=339884) is 17 years old, I have no idea why some things are encountering it now. Some core JQuery functions are broken when operating on popped out HTML nodes. Therefore **I am no longer supporting Firefox**, please use Chrome. If you are interested, the following gist can [replicate the issue](https://gist.github.com/Posnet/9d87f790d4f3c64ed468559600c76302).
-
-# Installation
-
-Install using the URL : `https://raw.githubusercontent.com/League-of-Foundry-Developers/fvtt-module-popout/master/module.json`
-
-As DM go to the `Manage Modules` options menu in your Game Settings tab then enable the `PopOut!` module.
-
-# Module Developers
+After installation, enable **PopOut!** in your world's **Manage Modules** menu.
 
 ## Compatibility
 
-**IMPORTANT** If your module ever accesses a HTML element, either by `document.getElementById` or `$(...selector...)` or similar functions that access a global document object. Your module will break if it is popped out, because those function calls will not find the correct element.
+- Module version: `2.24.0`
+- Foundry minimum: `12`
+- Verified with Foundry: `14.362`
+- Browser support: regular web browsers only
 
-You **must** always call `find` on the DOM object attached to the Foundry object. For example `sheet.element.find(...selector...)`.
+PopOut! does not work in Foundry's Electron desktop application window. If you host Foundry locally, use a browser such as Chrome pointed at your Foundry server instead.
 
-They reason for this is that PopOut! works by creating a new window and migrating DOM nodes from the main window to the new window.
-This ensures that event handlers and other related behavior is preserved, and that any assumptions about a Foundry application existing as a single JS object also remain true.
-However it does mean that the page now has 2 logical documents, not 1 because there are 2 or more windows.
-So any assumptions about being able to access something from the root window/document/jquery object are no longer true.
+PopOut! works by moving Foundry application DOM nodes into another browser window. That makes broad compatibility possible, but some sheets or modules that rely heavily on global `document` lookups, jQuery plugins, React, Svelte, Vue, or other framework-specific assumptions may still have limitations when popped out.
 
-### Tooltips
+## Changes
 
-Unfortunately an update to foundry-vtt (approximately v10) has broken the built in tool-tips functionality in a way that can't be fixed easily. I have added in a very brittle fix with the latest version, but it will likely break modules that are overriding or modifying tooltip behavior, such as calling `tooltip.activate` manually, but there is nothing I can currently do about this. A notable example of something that is basically unfix-able, is the tooltip in DnD 5e that breaks down AC by effect.
+### `2.24.0`
 
-### Disabling PopOut!
+- Verified PopOut! against Foundry `14.362`.
+- Updated module compatibility metadata for Foundry V14 and removed the stale maximum-version cap.
+- Incorporated the keyboard focus fix from PR [#163](https://github.com/League-of-Foundry-Developers/fvtt-module-popout/pull/163), credited to Sigiller, so typing in popped-out input fields is less likely to trigger Foundry hotbar digit shortcuts.
+- Preserved the existing PopOut! module id, behavior, hooks, and browser-only warning.
 
-If you are a module developer have found that PopOut! is not working correctly or it doesn't make sense for your application to be able to be popped out. You can add the property `_disable_popout_module` to your application, and this module will ignore it.
+## Module Developer Notes
 
-A second option is when creating an application or dialog, you can add the `popOutModuleDisable` attribute to it's options argument, this will also disable PopOut for that specific object. For example:
+If your module accesses HTML through global document lookups such as `document.getElementById(...)`, `document.querySelector(...)`, or `$(...)`, it may not find elements after an application is popped out. Prefer searching from the application element itself, for example:
+
+```js
+sheet.element.find(".my-control");
+```
+
+To prevent PopOut! from handling an application, set `_disable_popout_module` on the application or pass `popOutModuleDisable` in the application options.
 
 ```js
 Dialog.prompt({ title: "", options: { popOutModuleDisable: true } });
 ```
 
-### Sidebar (ChatLog...)
+PopOut! also exposes `PopoutModule.popoutApp(app)` and the existing PopOut hooks:
 
-Due to the way the sidebar popouts are implemented by Foundry, if you are searching for elements in them. You will have to do the same action again, for the popped out sidebar element.
+- `PopOut:popout`
+- `Popout:loading`
+- `Popout:loaded`
+- `PopOut:popin`
+- `PopOut:dialog`
+- `PopOut:close`
 
-For example if you want to hide a chat card, you will have to do the following.
+## Credits
 
-```js
-ui.chat.element.find(`.message[data-message-id=${data._id}]`).hide();
-if (ui.sidebar.popouts.chat) {
-  ui.sidebar.popouts.chat.element
-    .find(`.message[data-message-id=${data._id}]`)
-    .hide();
-}
-```
+PopOut! was written by KaKaRoTo and maintained by Posnet and the League of Foundry Developers.
 
-## Integration
-
-Popout! exposes a single API function and a series of hooks so other modules can leverage it's functionality.
-
-This API is new as of version 2.0, with the goal is to maintain API compatibility from this point on.
-
-_Note_: There was a minor compatibility break which is why 2.0 was released, the PopOut hook now only takes 2 arguments instead of 3.
-
-To pop out an application, call the function with the application object.
-
-```js
-// Where app is the foundry Application object. For example an actor sheet.
-// If the Application exists in the window.ui.windows map, it should be able to be popped out.
-PopoutModule.popoutApp(app);
-```
-
-PopOut also exposes hooks to developers to alter its behavior to add compatibility to their modules.
-For an example of what that might look like, see the PDFoundry compatibility hooks in [./popout.js](./popout.js#697)
-
-```javascript
-// app: is the foundry application being popped out.
-// popout: is the browser window object where the popped out element will be moved.
-Hooks.callAll("PopOut:popout", app, popout);
-
-// app: is the foundry application being popped out.
-// node: is the html element of the application after it has been moved to the new window.
-Hooks.callAll("Popout:loaded", app, node);
-
-// app: is the foundry application being popped out.
-// popout: is the browser window object where the popped out element will be moved.
-Hooks.callAll("Popout:loading", app, popout);
-
-// app: is the foundry application being popped in.
-Hooks.callAll("PopOut:popin", app);
-
-// app: is the foundry application being popped out.
-// parent: The application that PopOut believes owns the diaglog box.
-Hooks.callAll("PopOut:dialog", app, parent);
-
-// app: is the foundry application being popped out.
-// node: is the html element of the popped out application, before it is deleted or popped in.
-Hooks.callAll("PopOut:close", app, node);
-```
-
-# License
-
-This Foundry VTT module, written by @KaKaRoTo.
-It is currently maintained by @Posnet.
-
-This work is licensed under Foundry Virtual Tabletop [EULA - LIMITED LICENSE AGREEMENT FOR MODULE DEVELOPMENT](https://foundryvtt.com/article/license/)
-
-The contents of this module are licensed under a [Creative Commons Attribution 4.0 International License](./LICENSE.txt) where they do not conflict with the above Foundry License.
+This module is licensed under the Foundry Virtual Tabletop module development license terms and the Creative Commons Attribution 4.0 International License where applicable. See [LICENSE.txt](./LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@ PopOut! adds a button to most Foundry VTT actor sheets, item sheets, journal ent
 
 ## Install
 
-Install PopOut! from Foundry's **Add-on Modules** screen with this manifest URL:
+In Foundry, open **Add-on Modules > Install Module**, paste a manifest URL into **Manifest URL**, and install.
+
+Official upstream channel:
 
 ```text
 https://raw.githubusercontent.com/League-of-Foundry-Developers/fvtt-module-popout/master/module.json
+```
+
+Spencer's Foundry V14 compatibility build:
+
+```text
+https://github.com/SpencerZPoole/fvtt-module-popout/releases/latest/download/module.json
 ```
 
 After installation, enable **PopOut!** in your world's **Manage Modules** menu.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "popout",
   "title": "PopOut!",
   "description": "<p>This module adds a PopOut! button to most actor sheets, journal entries, and applications.</p><p>The PopOut! button allows you to open a sheet/application/document into its own window, for easier viewing or for use with multiple monitors.</p>",
-  "version": "2.23",
+  "version": "2.24.0",
   "authors": [{ "name": "KaKaRoTo" }, { "name": "Posnet" }],
   "scripts": ["./popout.js"],
   "styles": [],
@@ -48,11 +48,10 @@
   "readme": "https://github.com/League-of-Foundry-Developers/fvtt-module-popout#readme",
   "url": "https://github.com/League-of-Foundry-Developers/fvtt-module-popout",
   "manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/fvtt-module-popout/master/module.json",
-  "download": "https://github.com/League-of-Foundry-Developers/fvtt-module-popout/archive/v2.23.zip",
+  "download": "https://github.com/League-of-Foundry-Developers/fvtt-module-popout/archive/refs/tags/v2.24.0.zip",
   "bugs": "https://github.com/League-of-Foundry-Developers/fvtt-module-popout/issues",
   "compatibility": {
     "minimum": "12",
-    "verified": "13.345",
-    "maximum": "13"
+    "verified": "14.362"
   }
 }

--- a/popout.js
+++ b/popout.js
@@ -34,6 +34,46 @@ class PopoutModule {
     this.ID = (foundry?.utils?.randomID || randomID)(24);
   }
 
+  static isHTMLElement(element) {
+    const HTMLElementCtor = element?.ownerDocument?.defaultView?.HTMLElement;
+    return Boolean(HTMLElementCtor && element instanceof HTMLElementCtor);
+  }
+
+  static isKeyboardTypingContext(element) {
+    if (!PopoutModule.isHTMLElement(element)) return false;
+
+    if (["", "true"].includes(element.dataset.keyboardFocus)) return true;
+    if (element.dataset.keyboardFocus === "false") return false;
+    if (["INPUT", "SELECT", "TEXTAREA"].includes(element.tagName)) return true;
+    if (element.isContentEditable) return true;
+    if (element.tagName === "BUTTON" && element.form) return true;
+    return false;
+  }
+
+  static keyboardEventTargetsTypingContext(event) {
+    if (PopoutModule.isKeyboardTypingContext(event.target)) return true;
+
+    return (
+      typeof event.composedPath === "function" &&
+      event
+        .composedPath()
+        .some((element) => PopoutModule.isKeyboardTypingContext(element))
+    );
+  }
+
+  static cloneElementContents(target, source) {
+    target.replaceChildren(
+      ...Array.from(source.childNodes, (node) => node.cloneNode(true)),
+    );
+  }
+
+  static hasSameElementContents(target, source) {
+    if (target.childNodes.length !== source.childNodes.length) return false;
+    return Array.from(source.childNodes).every((node, index) =>
+      node.isEqualNode(target.childNodes[index]),
+    );
+  }
+
   log(msg, ...args) {
     if (game && game.settings.get("popout", "verboseLogs")) {
       const color = "background: #6699ff; color: #000; font-size: larger;";
@@ -267,17 +307,10 @@ class PopoutModule {
 
       // Helper function to check if an element has focus based on version
       const checkElementFocus = (element) => {
-        if (!(element instanceof HTMLElement)) return false;
+        if (!PopoutModule.isHTMLElement(element)) return false;
 
         if (isV13) {
-          // v13 logic with dataset and specific checks
-          if (["", "true"].includes(element.dataset.keyboardFocus)) return true;
-          if (element.dataset.keyboardFocus === "false") return false;
-          if (["INPUT", "SELECT", "TEXTAREA"].includes(element.tagName))
-            return true;
-          if (element.isContentEditable) return true;
-          if (element.tagName === "BUTTON" && element.form) return true;
-          return false;
+          return PopoutModule.isKeyboardTypingContext(element);
         } else {
           // v12 logic - any focused HTMLElement counts
           return true;
@@ -442,15 +475,22 @@ class PopoutModule {
       // Don't mirror empty content (happens when deactivate clears main tooltip)
       // Don't mirror if it's just a loading spinner (popout already has it)
       // Use querySelector for robust spinner detection across FA versions
+      const hasContent = mainTooltipElement.childNodes.length > 0;
       const isLoadingSpinner =
         mainTooltipElement.querySelector(".fa-spinner, .fa-spin, .loading") !==
         null;
       if (
-        content &&
-        content !== activePopoutTooltip.innerHTML &&
+        hasContent &&
+        !PopoutModule.hasSameElementContents(
+          activePopoutTooltip,
+          mainTooltipElement,
+        ) &&
         !isLoadingSpinner
       ) {
-        activePopoutTooltip.innerHTML = content;
+        PopoutModule.cloneElementContents(
+          activePopoutTooltip,
+          mainTooltipElement,
+        );
         popoutModule.log("Mirrored content to popout tooltip");
       }
     });
@@ -547,7 +587,7 @@ class PopoutModule {
       // the class is already present, so no mutation would fire).
       if (isPopout && mainTooltipElement !== this.tooltip) {
         mainTooltipElement.classList.remove("active");
-        mainTooltipElement.innerHTML = this.tooltip.innerHTML;
+        PopoutModule.cloneElementContents(mainTooltipElement, this.tooltip);
         // Hide the main tooltip - it's only used to trigger dnd5e's observer
         mainTooltipElement.style.visibility = "hidden";
         mainTooltipElement.style.pointerEvents = "none";
@@ -573,7 +613,7 @@ class PopoutModule {
       if (activePopoutTooltip && activePopoutTooltip !== mainTooltipElement) {
         try {
           mainTooltipElement.classList.remove("active");
-          mainTooltipElement.innerHTML = "";
+          mainTooltipElement.replaceChildren();
           // Restore visibility for normal tooltip usage
           mainTooltipElement.style.visibility = "";
           mainTooltipElement.style.pointerEvents = "";
@@ -806,8 +846,9 @@ class PopoutModule {
               headerButton.className =
                 "header-control icon popout-module-button";
               headerButton.type = "button";
-              headerButton.innerHTML =
-                '<i class="fas fa-external-link-alt"></i>';
+              const icon = document.createElement("i");
+              icon.className = "fas fa-external-link-alt";
+              headerButton.append(icon);
               headerButton.setAttribute(
                 "data-tooltip",
                 game.i18n.localize("POPOUT.PopOut"),
@@ -1551,6 +1592,8 @@ class PopoutModule {
       // Forward keyboard events to main window for keybinding support
       // NOTE: v13 changed the keyboard API, #handleKeyboardEvent is now private
       popout.addEventListener("keydown", (event) => {
+        if (PopoutModule.keyboardEventTargetsTypingContext(event)) return;
+
         if (window.keyboard && window.keyboard._handleKeyboardEvent) {
           // v12 and earlier - use internal method
           window.keyboard._handleKeyboardEvent(event, false);
@@ -1561,6 +1604,8 @@ class PopoutModule {
         }
       });
       popout.addEventListener("keyup", (event) => {
+        if (PopoutModule.keyboardEventTargetsTypingContext(event)) return;
+
         if (window.keyboard && window.keyboard._handleKeyboardEvent) {
           // v12 and earlier - use internal method
           window.keyboard._handleKeyboardEvent(event, true);

--- a/scripts/foundry-release.js
+++ b/scripts/foundry-release.js
@@ -25,7 +25,7 @@ async function release({ version, dryRun }) {
   // Use the manifest URL from module.json (always points to master)
   const manifest = module.manifest;
 
-  // Foundry expects version with 'v' prefix (e.g., v2.22)
+  // Foundry expects version with 'v' prefix (e.g., v2.24.0)
   const versionWithPrefix = version.startsWith("v") ? version : `v${version}`;
 
   const payload = {
@@ -34,7 +34,7 @@ async function release({ version, dryRun }) {
     release: {
       version: versionWithPrefix,
       manifest,
-      notes: `https://github.com/League-of-Foundry-Developers/fvtt-module-popout/releases/tag/${versionWithPrefix}`,
+      notes: `${module.url}/releases/tag/${versionWithPrefix}`,
       compatibility: module.compatibility,
     },
   };


### PR DESCRIPTION
## Summary

This updates PopOut! for current Foundry V14 usage while preserving the existing module id, public API, hooks, and browser-only behavior.

Changes included:
- verify compatibility through Foundry `14.362` and remove the stale maximum-version cap
- update README/module metadata for an upstream `2.24.0` release
- incorporate the popped-out input keyboard focus fix from PR #163, credited to Sigiller, so typing in popped-out inputs is less likely to trigger Foundry hotbar digit shortcuts
- keep tooltip mirroring behavior while avoiding direct HTML assignment for mirrored tooltip content and the ApplicationV2 header icon
- allow the release workflow version input to accept patch versions such as `2.24.0`

I included the #163-style focus fix here because it was important in local V14 testing. Happy to adjust if maintainers prefer to merge #163 independently and keep this PR focused only on V14 verification/metadata.

## Validation

- Installed and tested locally in Foundry `14.362` with D35E `3.0.2`
- User testing confirmed PopOut! and Popout Resizer are working together before opening this PR
- `node --check popout.js`
- `node --check scripts/foundry-release.js`
- `npm run lint`
- manifest/reference validation for scripts, languages, README, license, upstream URLs, and compatibility metadata
- package-shape check with `module.json`, `popout.js`, `LICENSE.txt`, `README.md`, and language files at zip root
- local security gate on changed files: `0 errors`, `0 warnings`

A public fork release used for install testing is available at:
https://github.com/SpencerZPoole/fvtt-module-popout/releases/tag/v2.24.0
