### PR TITLE
Bump compatibility to Foundry V14 (verified 14.363)

### DIFF
--- a/module.json
+++ b/module.json
@@ -52,7 +52,7 @@
   "bugs": "https://github.com/League-of-Foundry-Developers/fvtt-module-popout/issues",
   "compatibility": {
     "minimum": "12",
-    "verified": "13.345",
-    "maximum": "13"
+    "verified": "14.363",
+    "maximum": "14"
   }
 }


### PR DESCRIPTION
Bumps the manifest compatibility block to Foundry V14:

- `verified`: 13.345 → 14.363
- `maximum`: 13 → 14

No code changes, the existing module loads and runs cleanly on V14 once the maximum cap is removed.

Closes #165.

## Test plan

Tested on Foundry V14.363 against PF2e v8.1.2 with ~20 modules loaded (browser client):

- [x] PopOut! buttons attach to actor sheets, item sheets, journal entries, and dialogs
- [x] Popped-out sheets render correctly with full styling
- [x] Interactive features work in the popped-out window: rolls, link clicks, drag-and-drop from sidebar
- [x] TooltipManager patching survives the V14 application lifecycle
- [x] Closing the popout returns the sheet to the main window cleanly

Since many system sheets (PF2e among them) are still on ApplicationV1 in V14, V14's native window-popout control doesn't apply to them, PopOut! remains the only way to detach those sheets to a second monitor.