### PR TITLE
Fix child dialogs not following a popped-out window (v13)

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -698,12 +698,6 @@ class PopoutModule {
       return;
     }
 
-    // Check if this is a system UI element that shouldn't be popped out
-    if (this.isSystemUI(app)) {
-      this.log("Ignoring system UI element", app.constructor.name);
-      return;
-    }
-
     let waitRender = Math.floor(this.MAX_TIMEOUT / this.TIMEOUT_INTERVAL);
 
     // Check render state for both v1 and v2 apps
@@ -748,6 +742,17 @@ class PopoutModule {
     }
 
     if (this.handleChildDialog(app)) {
+      return;
+    }
+
+    // Check if this is a system UI element that shouldn't be popped out.
+    // NOTE: this runs AFTER handleChildDialog (and after the render wait) so that a
+    // child dialog of a popped-out window (e.g. a roll/level/config prompt) can follow
+    // its parent into the popout. isSystemUI classifies every constructor.name of
+    // "Dialog"/"Application" as system UI, which would otherwise block the move on v13.
+    // Standalone system dialogs are still skipped here.
+    if (this.isSystemUI(app)) {
+      this.log("Ignoring system UI element", app.constructor.name);
       return;
     }
 
@@ -949,12 +954,10 @@ class PopoutModule {
   }
 
   moveDialog(app, parentApp) {
-    // Don't move system UI dialogs
-    if (this.isSystemUI(app)) {
-      this.log("Not moving system UI dialog", app.constructor.name);
-      return;
-    }
-
+    // No isSystemUI guard here: moveDialog is only ever reached from handleChildDialog,
+    // which has already confirmed this app is a child dialog of a popped-out window. The
+    // previous guard re-blocked every constructor.name === "Dialog" app and so disabled
+    // dialog-follow entirely on v13.
     const parentId = parentApp.appId || parentApp.id;
     const parent = this.poppedOut.get(parentId);
     const dialogNode = this.getAppElement(app);


### PR DESCRIPTION
## Problem
A child dialog opened from a popped-out sheet — a roll prompt, a level-up dialog, a config prompt, etc. — stays in the main window instead of following its parent into the popout.

## Cause
`isSystemUI()` classifies every app whose `constructor.name` is `"Dialog"` or `"Application"` as system UI. `addPopout()` ran `isSystemUI()` **before** `handleChildDialog()`, so a child `Dialog` was treated as system UI and returned early before the child-dialog path could run; `moveDialog()` then re-applied the same guard. On v13, where more prompts are plain `Dialog` instances, this disabled dialog-follow entirely.

## Fix
`addPopout()` now runs `handleChildDialog()` first and only falls through to the `isSystemUI()` check for apps that are **not** a child dialog of a popped-out window. `moveDialog()` drops its now-redundant guard. Standalone system dialogs are still skipped.

## Testing
Verified on Foundry **v13.350**: pop out a sheet, trigger a child Dialog from it (e.g. a roll or config prompt), and the dialog now opens in the popout window alongside its parent. Standalone system dialogs (HUD, scene controls, navigation) are still not popped out.
