### PR TITLE
i18n: clarify the standalone desktop-app (Electron) warning

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -11,6 +11,6 @@
   "POPOUT.verboseLogsHint": "Enables detailed module logging in the console. Useful for debugging issues.",
   "POPOUT.enableTooltips": "Enable tooltip support",
   "POPOUT.enableTooltipsHint": "Enables tooltips to display correctly in popped out windows. Disable if you experience tooltip-related issues.",
-  "POPOUT.electronWarning": "Popout! cannot work within the standalone FVTT Application. Please open your game from a regular browser.",
+  "POPOUT.electronWarning": "PopOut! cannot open separate windows in the standalone Foundry desktop app, which blocks them for security. To use PopOut!, open your game in a web browser such as Chrome instead.",
   "POPOUT.failureWarning": "Unable to open PopOut! window. Please check your site settings/permissions. Click the <i class='fas fa-info-circle'></i> to the left of the website URL."
 }


### PR DESCRIPTION
Wording-only change to the `POPOUT.electronWarning` string (English).

The old message said only that PopOut! "cannot work within the standalone FVTT Application." The new message explains **why** (the desktop app blocks `window.open` for security) and tells the user **what to do instead** (open the game in a web browser such as Chrome):

> PopOut! cannot open separate windows in the standalone Foundry desktop app, which blocks them for security. To use PopOut!, open your game in a web browser such as Chrome instead.

Only `lang/en.json` is touched; other locales are left to translators.
